### PR TITLE
avoid generating empty data files

### DIFF
--- a/fitbit_dump/__main__.py
+++ b/fitbit_dump/__main__.py
@@ -288,7 +288,15 @@ async def fetch_activity_tcx(activity, auth=None, activity_directory=pathlib.Pat
     async with session.get(activity['tcxLink'], headers={'Authorization': f"Bearer {auth}"}) as req:
       with outfile.open('wb') as fw:
         async for chunk in req.content.iter_chunked(CHUNK_SIZE):
-          fw.write(chunk)
+          if chunk.decode() == 'Too Many Requests': # checking if reached API limits
+            print("Reached 150/hour request limit, waiting...")
+            logging.debug(f"Reached maximum hourly API requests. waiting...")
+
+            await asyncio.sleep(3610)
+            await fetch_activity_tcx(activity, auth, activity_directory)
+            return
+          else:
+            fw.write(chunk)
 
 # CLI
 


### PR DESCRIPTION
I noticed that this code generated a lot of .tcx files with only one line of text in it.

`Too Many Requests` was the only line in those files...

the root cause is that the Fitbit API only allows 150 requests per hour. [ref: [1](https://community.fitbit.com/t5/Web-API-Development/Too-many-request/td-p/1644362)]

The solution I proposed is to wait for 3610 seconds(1 hour 10 seconds) before retrying.